### PR TITLE
Update fr.js

### DIFF
--- a/unmin/js/i18n/fr.js
+++ b/unmin/js/i18n/fr.js
@@ -54,8 +54,8 @@ wb.i18nDict = {
 
 	nxt: "Suivant",
 	"nxt-r": "Suivant (touche droite)",
-	prv: "Précedent",
-	"prv-l": "Précedent (touche gauche)",
+	prv: "Précédent",
+	"prv-l": "Précédent (touche gauche)",
 	first: "Premier",
 	last: "Dernier",
 	"srch-menus": "Recherche et menus",


### PR DESCRIPTION
Correcting the spelling of Précédent, 2 out of 3 instances were spelled Précedent
