### PR TITLE
Change radio button question to yes/no

### DIFF
--- a/demos/formvalid/formvalid-en.html
+++ b/demos/formvalid/formvalid-en.html
@@ -458,18 +458,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 		&lt;/fieldset&gt;</code></pre>
 </details>
 <fieldset>
-<legend class="required"><span class="field-name">Citizenship status</span> <strong class="required">(required)</strong></legend>
+<legend class="required"><span class="field-name">Are you a Canadian Citizen?</span> <strong class="required">(required)</strong></legend>
 <div class="radio">
-<label for="status1"><input type="radio" name="status" value="1" id="status1" required="required">&#160;&#160;Canadian citizen</label>
+<label for="status1"><input type="radio" name="status" value="1" id="status1" required="required">&#160;&#160;Yes</label>
 </div>
 <div class="radio">
-<label for="status2"><input type="radio" name="status" value="2" id="status2">&#160;&#160;Permanent resident</label>
-</div>
-<div class="radio">
-<label for="status3"><input type="radio" name="status" value="3" id="status3">&#160;&#160;Work permit</label>
-</div>
-<div class="radio">
-<label for="status4"><input type="radio" name="status" value="4" id="status4">&#160;&#160;Other</label>
+<label for="status2"><input type="radio" name="status" value="2" id="status2">&#160;&#160;No</label>
 </div>
 </fieldset>
 <details class="mrgn-bttm-md">


### PR DESCRIPTION
Recommend only using radio button questions for yes/no, on/off and other very clear choices. Screen reader users can't seem to tell them from checkboxes, would select a second option and unknowingly lose the first. So changing this radio button demo to just yes no.

If this is ok, will do the French one too. 
